### PR TITLE
Live tests

### DIFF
--- a/R/osrm_install.R
+++ b/R/osrm_install.R
@@ -313,7 +313,13 @@ osrm_install <- function(
   on.exit(unlink(tmp_extract_dir, recursive = TRUE), add = TRUE)
   emit_message("Extracting binaries...")
   tryCatch(
-    utils::untar(tmp_file, exdir = tmp_extract_dir),
+    {
+      if (quiet) {
+        suppressWarnings(utils::untar(tmp_file, exdir = tmp_extract_dir))
+      } else {
+        utils::untar(tmp_file, exdir = tmp_extract_dir)
+      }
+    },
     error = function(e) {
       stop("Failed to extract archive: ", e$message, call. = FALSE)
     }
@@ -1026,7 +1032,7 @@ install_profiles_for_release <- function(
   ))
   suppress_tar_warnings <- !allow_tar_warnings_env %in% c("1", "true", "yes")
   run_untar <- function(arg_list) {
-    if (suppress_tar_warnings) {
+    if (quiet || suppress_tar_warnings) {
       suppressWarnings(do.call(utils::untar, arg_list))
     } else {
       do.call(utils::untar, arg_list)
@@ -1063,23 +1069,10 @@ install_profiles_for_release <- function(
     )
   }
 
-  # Extract only the top-level 'profiles' subtree shipped with the release.
-  top_level_dirs <- unique(sub("/.*$", "", tar_members))
-  top_level_dirs <- top_level_dirs[nzchar(top_level_dirs)]
-  top_level_dir <- top_level_dirs[[1]]
-
-  prefix <- paste0(top_level_dir, "/")
-  relative_members <- tar_members
-  matches_prefix <- startsWith(relative_members, prefix)
-  relative_members[matches_prefix] <- substr(
-    relative_members[matches_prefix],
-    nchar(prefix) + 1,
-    nchar(relative_members[matches_prefix])
-  )
-
-  profile_mask <- startsWith(relative_members, "profiles/") |
-    relative_members %in% c("profiles", "profiles/")
-
+  # Identify all members that belong to a 'profiles' directory.
+  # We look for 'profiles/' anywhere in the path, as GitHub tarballs
+  # usually have a repo-version/ prefix.
+  profile_mask <- grepl("(^|/)profiles(/|$)", tar_members)
   profile_members <- tar_members[profile_mask]
 
   if (length(profile_members) == 0) {
@@ -1089,18 +1082,11 @@ install_profiles_for_release <- function(
     )
   }
 
-  profile_dirs <- unique(
-    sub("^(.*?/profiles)(?:/.*)?$", "\\1", profile_members, perl = TRUE)
-  )
-  profile_dirs <- profile_dirs[
-    nzchar(profile_dirs) &
-      !grepl("[[:cntrl:]]", profile_dirs, perl = TRUE)
-  ]
-  extract_members <- profile_members
-  extract_members <- extract_members[
-    nzchar(extract_members) &
-      !grepl("[[:cntrl:]]", extract_members, perl = TRUE)
-  ]
+  # Clean up member names for extraction (remove leading/trailing whitespace if any)
+  extract_members <- unique(trimws(profile_members))
+  extract_members <- extract_members[nzchar(extract_members)]
+  # Remove entries with control characters (safety)
+  extract_members <- extract_members[!grepl("[[:cntrl:]]", extract_members)]
 
   if (!quiet) {
     message("Extracting profiles...")
@@ -1119,13 +1105,21 @@ install_profiles_for_release <- function(
   last_extract_error <- NULL
   extracted <- FALSE
   for (args in untar_attempts) {
-    tryCatch(
+    # On some systems untar returns the exit status. We treat 0 as success.
+    # On others it might return NULL or throw an error.
+    status <- tryCatch(
       {
-        run_untar(args)
-        extracted <- TRUE
+        res <- run_untar(args)
+        if (is.null(res) || identical(res, 0L)) {
+          extracted <- TRUE
+        } else {
+          last_extract_error <<- list(message = paste("tar exit status", res))
+        }
+        TRUE
       },
       error = function(e) {
         last_extract_error <<- e
+        FALSE
       }
     )
     if (isTRUE(extracted)) {
@@ -1151,10 +1145,11 @@ install_profiles_for_release <- function(
   ]
   if (length(profile_dirs_found) == 0) {
     stop(
-      "The release tarball did not contain a 'profiles' directory.",
+      "The profiles directory was not correctly extracted from the tarball.",
       call. = FALSE
     )
   }
+  # Pick the shallowest 'profiles' directory
   profile_source <- profile_dirs_found[[which.min(nchar(profile_dirs_found))]]
 
   dest_profiles_dir <- file.path(dest_dir, "profiles")
@@ -1236,7 +1231,8 @@ install_windows_v6_runtime <- function(dest_dir, quiet = FALSE) {
     url = tbb_url,
     member_path = "oneapi-tbb-2022.3.0/redist/intel64/vc14/tbb12.dll",
     dest_path = file.path(dest_dir, "tbb12.dll"),
-    sha256 = "e1b2373f25558bf47d16b4c89cf0a31e6689aaf7221400d209e8527afc7c9eee"
+    sha256 = "e1b2373f25558bf47d16b4c89cf0a31e6689aaf7221400d209e8527afc7c9eee",
+    quiet = quiet
   )
   if (!quiet) {
     message("  - Installed tbb12.dll")
@@ -1250,7 +1246,8 @@ install_windows_v6_runtime <- function(dest_dir, quiet = FALSE) {
     url = bzip_url,
     member_path = "libbz2.dll",
     dest_path = file.path(dest_dir, "bz2.dll"),
-    sha256 = "50340fece047960f49cf869034c778ff9f6af27dde2f1ea9773cd89ddb326254"
+    sha256 = "50340fece047960f49cf869034c778ff9f6af27dde2f1ea9773cd89ddb326254",
+    quiet = quiet
   )
   if (!quiet) {
     message("  - Installed bz2.dll")
@@ -1345,7 +1342,13 @@ ensure_linux_tbb_runtime <- function(
   on.exit(unlink(tmp_extract_dir, recursive = TRUE), add = TRUE)
 
   tryCatch(
-    utils::untar(tmp_tar, exdir = tmp_extract_dir),
+    {
+      if (quiet) {
+        suppressWarnings(utils::untar(tmp_tar, exdir = tmp_extract_dir))
+      } else {
+        utils::untar(tmp_tar, exdir = tmp_extract_dir)
+      }
+    },
     error = function(e) {
       stop(
         "Failed to extract OSRM release ",
@@ -1479,7 +1482,13 @@ ensure_macos_tbb_runtime <- function(
   on.exit(unlink(tmp_extract_dir, recursive = TRUE), add = TRUE)
 
   tryCatch(
-    utils::untar(tmp_tar, exdir = tmp_extract_dir),
+    {
+      if (quiet) {
+        suppressWarnings(utils::untar(tmp_tar, exdir = tmp_extract_dir))
+      } else {
+        utils::untar(tmp_tar, exdir = tmp_extract_dir)
+      }
+    },
     error = function(e) {
       stop(
         "Failed to extract OSRM release ",
@@ -1647,7 +1656,7 @@ version_at_least <- function(version, minimum) {
 
 #' @noRd
 # Download a zip archive, verify its checksum, and extract a single file.
-download_zip_asset <- function(url, member_path, dest_path, sha256 = NULL) {
+download_zip_asset <- function(url, member_path, dest_path, sha256 = NULL, quiet = FALSE) {
   member_path <- gsub("^/+", "", member_path)
   normalized_member <- gsub("\\\\", "/", member_path)
 
@@ -1687,7 +1696,12 @@ download_zip_asset <- function(url, member_path, dest_path, sha256 = NULL) {
     }
   }
 
-  contents <- utils::unzip(tmp_zip, list = TRUE)
+  contents <- if (quiet) {
+    suppressWarnings(utils::unzip(tmp_zip, list = TRUE))
+  } else {
+    utils::unzip(tmp_zip, list = TRUE)
+  }
+
   if (is.null(contents) || nrow(contents) == 0) {
     stop(
       sprintf("Archive '%s' did not contain any files.", basename(url)),
@@ -1714,7 +1728,13 @@ download_zip_asset <- function(url, member_path, dest_path, sha256 = NULL) {
   on.exit(unlink(tmp_extract, recursive = TRUE), add = TRUE)
 
   tryCatch(
-    utils::unzip(tmp_zip, files = selected_member, exdir = tmp_extract),
+    {
+      if (quiet) {
+        suppressWarnings(utils::unzip(tmp_zip, files = selected_member, exdir = tmp_extract))
+      } else {
+        utils::unzip(tmp_zip, files = selected_member, exdir = tmp_extract)
+      }
+    },
     error = function(e) {
       stop(
         sprintf(

--- a/R/osrm_install.R
+++ b/R/osrm_install.R
@@ -57,8 +57,8 @@
 #' @param version A string specifying the OSRM version tag to install.
 #'   Defaults to `"latest"`. Use `"latest"` to automatically find the most
 #'   recent stable version (internally calls [osrm_check_latest_version()]). Versions
-#'   other than `v5.27.1`, `v6.0.0`, `v26.4.0` and `v26.4.1` will trigger a
-#'   warning but are still attempted if binaries are available.
+#'   other than `v5.27.1`, `v6.0.0`, `v26.4.0`, `v26.4.1`, and `v26.5.0` will
+#'   trigger a warning but are still attempted if binaries are available.
 #' @param dest_dir A string specifying the directory where OSRM binaries should be
 #'   installed. If `NULL` (the default), a user-friendly, persistent location is
 #'   chosen via `tools::R_user_dir("osrm.backend", which = "cache")`, and the
@@ -77,6 +77,9 @@
 #'   }
 #' @param quiet A logical value. If `TRUE`, suppresses installer messages and
 #'   warnings. Defaults to `FALSE`.
+#' @param check_tested A logical value. If `TRUE` (default), the function issues
+#'   a warning if the requested OSRM version has not been explicitly validated
+#'   by the package maintainers. If `FALSE`, it issues a status message instead.
 #' @return The path to the installation directory.
 #' @export
 #' @examples
@@ -106,7 +109,8 @@ osrm_install <- function(
   dest_dir = NULL,
   force = FALSE,
   path_action = c("session", "project", "none"),
-  quiet = FALSE
+  quiet = FALSE,
+  check_tested = TRUE
 ) {
   quiet <- isTRUE(quiet)
   emit_message <- function(...) {
@@ -133,7 +137,7 @@ osrm_install <- function(
   }
 
   # --- 2. Determine version and get release info ---
-  tested_versions <- c("v5.27.1", "v6.0.0", "v26.4.0", "v26.4.1")
+  tested_versions <- c("v5.27.1", "v6.0.0", "v26.4.0", "v26.4.1", "v26.5.0")
   requested_version <- version
   mac_release_display <- mac_release_info$display_name
   if (is.null(mac_release_display) || !nzchar(mac_release_display)) {
@@ -197,7 +201,11 @@ osrm_install <- function(
         paste(tested_versions, collapse = ", ")
       )
     }
-    emit_warning(warning_message, call. = FALSE)
+    if (isTRUE(check_tested)) {
+      emit_warning(warning_message, call. = FALSE)
+    } else {
+      emit_message(warning_message)
+    }
   }
 
   # Validate requested tag exists for this platform before hitting the API.

--- a/man/osrm_install.Rd
+++ b/man/osrm_install.Rd
@@ -9,15 +9,16 @@ osrm_install(
   dest_dir = NULL,
   force = FALSE,
   path_action = c("session", "project", "none"),
-  quiet = FALSE
+  quiet = FALSE,
+  check_tested = TRUE
 )
 }
 \arguments{
 \item{version}{A string specifying the OSRM version tag to install.
 Defaults to \code{"latest"}. Use \code{"latest"} to automatically find the most
 recent stable version (internally calls \code{\link[=osrm_check_latest_version]{osrm_check_latest_version()}}). Versions
-other than \code{v5.27.1}, \code{v6.0.0}, \code{v26.4.0} and \code{v26.4.1} will trigger a
-warning but are still attempted if binaries are available.}
+other than \code{v5.27.1}, \code{v6.0.0}, \code{v26.4.0}, \code{v26.4.1}, and \code{v26.5.0} will
+trigger a warning but are still attempted if binaries are available.}
 
 \item{dest_dir}{A string specifying the directory where OSRM binaries should be
 installed. If \code{NULL} (the default), a user-friendly, persistent location is
@@ -40,6 +41,10 @@ the \code{PATH} for all future sessions in that project.
 
 \item{quiet}{A logical value. If \code{TRUE}, suppresses installer messages and
 warnings. Defaults to \code{FALSE}.}
+
+\item{check_tested}{A logical value. If \code{TRUE} (default), the function issues
+a warning if the requested OSRM version has not been explicitly validated
+by the package maintainers. If \code{FALSE}, it issues a status message instead.}
 }
 \value{
 The path to the installation directory.

--- a/tests/testthat/setup-osrm.R
+++ b/tests/testthat/setup-osrm.R
@@ -13,7 +13,7 @@ dir.create(test_osrm_path, showWarnings = FALSE, recursive = TRUE)
 # We skip installation on CRAN to avoid timeouts and policy violations.
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Running locally/CI: Installing OSRM binary to tempdir...")
-  try(osrm_install(version = "v5.27.1", path = test_osrm_path, quiet = TRUE), silent = TRUE)
+  try(osrm_install(version = "v5.27.1", dest_dir = test_osrm_path, quiet = TRUE), silent = TRUE)
 } else {
   message("Running on CRAN: Skipping OSRM binary installation.")
 }

--- a/tests/testthat/test-live-integration.R
+++ b/tests/testthat/test-live-integration.R
@@ -50,7 +50,13 @@ test_that("Live installation and basic routing works for all supported OSRM vers
     
     # We use path_action="none" to avoid messing with .Rprofile in CI
     # This MUST succeed
-    install_path <- osrm_install(version = ver, dest_dir = test_dir, path_action = "none", quiet = FALSE)
+    install_path <- osrm_install(
+      version = ver,
+      dest_dir = test_dir,
+      path_action = "none",
+      quiet = FALSE,
+      check_tested = FALSE
+    )
     
     # 2. VERIFY BINARIES
     routed_bin <- list.files(install_path, pattern = "^osrm-routed(\\.exe)?$", full.names = TRUE)

--- a/tests/testthat/test-live-integration.R
+++ b/tests/testthat/test-live-integration.R
@@ -90,6 +90,41 @@ test_that("Live installation and basic routing works for all supported OSRM vers
     # 5. LIVENESS CHECK
     expect_true(srv$is_alive())
     
+    # 5.1 ROUTING TEST (API level)
+    # This uses httr2 (an Import) to verify the server is actually responding to requests.
+    url <- sprintf("http://localhost:%d/route/v1/car/-49.28,-25.44;-49.26,-25.42?overview=false", port)
+    resp <- httr2::request(url) %>% httr2::req_perform()
+    expect_equal(httr2::resp_status(resp), 200)
+    
+    body <- httr2::resp_body_json(resp)
+    expect_equal(body$code, "Ok")
+    expect_gt(length(body$routes), 0)
+    
+    # 5.2 ROUTING TEST (osrm package level)
+    if (requireNamespace("osrm", quietly = TRUE)) {
+      withr::with_options(
+        list(
+          osrm.server = sprintf("http://localhost:%d/", port),
+          osrm.profile = "car"
+        ),
+        {
+          # Run a simple route
+          # Points in Curitiba (cur.osm.pbf)
+          route <- osrm::osrmRoute(
+            src = c(-49.28, -25.44),
+            dst = c(-49.26, -25.42),
+            overview = "full"
+          )
+          
+          # Basic validation of routing response
+          expect_s3_class(route, "sf")
+          expect_gt(nrow(route), 0)
+          expect_gt(route$distance, 0)
+          expect_gt(route$duration, 0)
+        }
+      )
+    }
+    
     # 6. STOP SERVER
     expect_message(
       stopped <- osrm_stop(srv),

--- a/tests/testthat/test-osrm_install.R
+++ b/tests/testthat/test-osrm_install.R
@@ -755,3 +755,35 @@ test_that("set_path_project replaces old cached version with new one", {
 
 # Integration tests with mocking would go here if we had a mocking framework
 # For now, the actual osrm_install function is tested in the setup-osrm.R
+
+# Test version validation logic ----
+test_that("osrm_install handles check_tested correctly", {
+  # We use a dummy dest_dir to avoid actual installation and bypass API checks if possible
+  # but here we just want to see if the message/warning is emitted.
+  # We'll need to mock/catch the execution before it hits the network if possible, 
+  # or just use expect_warning/expect_message and let it try (and fail) or stop early.
+  
+  dummy_dest <- tempfile()
+  dir.create(dummy_dest)
+  on.exit(unlink(dummy_dest, recursive = TRUE))
+
+  # Test 1: Validated version (v26.5.0) should be silent
+  # We use force = TRUE to ensure it doesn't stop because it already exists
+  # We use quiet = TRUE to suppress other messages
+  expect_silent(
+    try(osrm_install(version = "v26.5.0", dest_dir = dummy_dest, force = TRUE, quiet = TRUE), silent = TRUE)
+  )
+
+  # Test 2: Untested version should warn by default
+  # It will likely fail later on GitHub API check, but the warning happens early
+  expect_warning(
+    try(osrm_install(version = "v99.9.9", dest_dir = dummy_dest, force = TRUE, quiet = FALSE), silent = TRUE),
+    "has not been validated"
+  )
+
+  # Test 3: Untested version with check_tested = FALSE should message
+  expect_message(
+    try(osrm_install(version = "v99.9.9", dest_dir = dummy_dest, check_tested = FALSE, force = TRUE, quiet = FALSE), silent = TRUE),
+    "has not been validated"
+  )
+})


### PR DESCRIPTION
This pull request updates the OSRM installer to support a new validated version, adds a new argument to control warning behavior for untested versions, and expands integration tests to verify both the new argument and routing functionality. The most important changes are:

### OSRM Version Validation

* Added `v26.5.0` to the list of explicitly validated OSRM versions in both the documentation and implementation, so it no longer triggers a warning when installed. [[1]](diffhunk://#diff-81411dfbb29d51e9afc565f1fa76807e7b1682a467959960764227d9864d9790L60-R61) [[2]](diffhunk://#diff-81411dfbb29d51e9afc565f1fa76807e7b1682a467959960764227d9864d9790L136-R140) [[3]](diffhunk://#diff-d04a021bd283058c9a96c386ab574fcd84c6aea59fc7882fab5af50ba6d53e37L12-R21)

### Installer Argument and Behavior

* Introduced a new `check_tested` argument to `osrm_install()`. When `TRUE` (default), the function warns if the requested OSRM version is unvalidated; when `FALSE`, it issues a status message instead. This is reflected in both the function and its documentation. [[1]](diffhunk://#diff-81411dfbb29d51e9afc565f1fa76807e7b1682a467959960764227d9864d9790R80-R82) [[2]](diffhunk://#diff-81411dfbb29d51e9afc565f1fa76807e7b1682a467959960764227d9864d9790L109-R113) [[3]](diffhunk://#diff-81411dfbb29d51e9afc565f1fa76807e7b1682a467959960764227d9864d9790R204-R208) [[4]](diffhunk://#diff-d04a021bd283058c9a96c386ab574fcd84c6aea59fc7882fab5af50ba6d53e37R44-R47)

### Testing

* Updated live integration tests to pass `check_tested = FALSE` to avoid warnings when testing unvalidated versions.
* Added a new test to verify that the `check_tested` argument correctly switches between warning and message behavior for unvalidated versions, and is silent for validated versions.
* Enhanced live integration tests to include direct API-level and package-level routing checks, ensuring that installed OSRM binaries respond as expected.