### PR TITLE
tests: prefer available OSRM releases; avoid hard-coded v26.7.2

### DIFF
--- a/tests/testthat/setup-osrm.R
+++ b/tests/testthat/setup-osrm.R
@@ -5,7 +5,9 @@ Sys.setenv(OSRM_BACKEND_ALLOW_TAR_WARNINGS = "true")
 test_osrm_path <- file.path(tempdir(), "osrm_bin_test")
 
 # Clean up any previous runs to ensure a fresh state
-if (dir.exists(test_osrm_path)) unlink(test_osrm_path, recursive = TRUE)
+if (dir.exists(test_osrm_path)) {
+  unlink(test_osrm_path, recursive = TRUE)
+}
 dir.create(test_osrm_path, showWarnings = FALSE, recursive = TRUE)
 
 # POLITE INSTALLATION:
@@ -13,13 +15,31 @@ dir.create(test_osrm_path, showWarnings = FALSE, recursive = TRUE)
 # We skip installation on CRAN to avoid timeouts and policy violations.
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Running locally/CI: Installing OSRM binary to tempdir...")
-  try(osrm_install(version = "v26.7.2", dest_dir = test_osrm_path, quiet = TRUE), silent = TRUE)
+  test_osrm_versions <- tryCatch(
+    osrm_check_available_versions(prereleases = TRUE),
+    error = function(...) character()
+  )
+  if (length(test_osrm_versions)) {
+    try(
+      osrm_install(
+        version = test_osrm_versions[[1]],
+        dest_dir = test_osrm_path,
+        quiet = TRUE
+      ),
+      silent = TRUE
+    )
+  }
 } else {
   message("Running on CRAN: Skipping OSRM binary installation.")
 }
 
 # CONFIGURATION (Only runs if binary exists):
-bin_path <- list.files(test_osrm_path, pattern = "^osrm-routed(\\.exe)?$", full.names = TRUE, recursive = TRUE)
+bin_path <- list.files(
+  test_osrm_path,
+  pattern = "^osrm-routed(\\.exe)?$",
+  full.names = TRUE,
+  recursive = TRUE
+)
 
 if (length(bin_path) > 0) {
   exe_path <- normalizePath(bin_path[1], mustWork = FALSE)
@@ -34,7 +54,9 @@ if (length(bin_path) > 0) {
 
   # Add to PATH so Sys.which finds it
   old_path <- Sys.getenv("PATH")
-  Sys.setenv(PATH = paste(dirname(exe_path), old_path, sep = .Platform$path.sep))
+  Sys.setenv(
+    PATH = paste(dirname(exe_path), old_path, sep = .Platform$path.sep)
+  )
 }
 
 # Helper functions to check for required binaries and profiles

--- a/tests/testthat/test-compatibility.R
+++ b/tests/testthat/test-compatibility.R
@@ -1,88 +1,183 @@
 test_that("Cross-provider compatibility works for latest versions", {
-  skip_if_not(identical(Sys.getenv("RUN_OSRM_LIVE_TESTS"), "true"), "Live OSRM tests skipped")
-  
+  skip_if_not(
+    identical(Sys.getenv("RUN_OSRM_LIVE_TESTS"), "true"),
+    "Live OSRM tests skipped"
+  )
+
   test_map <- tempfile(fileext = ".osm.pbf")
-  download.file("https://download.geofabrik.de/europe/monaco-latest.osm.pbf", test_map, quiet = TRUE)
-  
+  download.file(
+    "https://download.geofabrik.de/europe/monaco-latest.osm.pbf",
+    test_map,
+    quiet = TRUE
+  )
+
+  old_repo <- options(osrm.backend.repository = "e-kotov/osrm-binaries")
+  on.exit(options(old_repo), add = TRUE)
   test_versions <- osrm_check_available_versions(prereleases = FALSE)
-  
+  options(osrm.backend.repository = "Project-OSRM/osrm-backend")
+  official_versions <- osrm_check_available_versions(prereleases = FALSE)
+  options(old_repo)
+
+  test_versions <- intersect(test_versions, official_versions)
+  skip_if_not(
+    length(test_versions) > 0,
+    "No versions available from both providers"
+  )
+
+  tested_any <- FALSE
+
   for (ver in test_versions) {
     dir_official <- tempfile()
     dir.create(dir_official)
-    
-    has_official <- tryCatch({
-      osrm_install(version = ver, osrm_binaries_provider = "official", dest_dir = dir_official, quiet = TRUE)
-      TRUE
-    }, error = function(e) FALSE)
-    
+
+    has_official <- tryCatch(
+      {
+        osrm_install(
+          version = ver,
+          osrm_binaries_provider = "official",
+          dest_dir = dir_official,
+          quiet = TRUE
+        )
+        TRUE
+      },
+      error = function(e) FALSE
+    )
+
     dir_ours <- tempfile()
     dir.create(dir_ours)
-    osrm_install(version = ver, osrm_binaries_provider = "default", dest_dir = dir_ours, quiet = TRUE)
-    
+    osrm_install(
+      version = ver,
+      osrm_binaries_provider = "default",
+      dest_dir = dir_ours,
+      quiet = TRUE
+    )
+
     if (has_official) {
       map_official <- tempfile(fileext = ".osm.pbf")
       file.copy(test_map, map_official)
-      
+
       opts <- options(osrm.backend.path = dir_official)
-      job_official <- osrm_prepare_graph(map_official, profile = osrm_find_profile("car.lua"), verbosity = "NONE")
+      job_official <- tryCatch(
+        osrm_prepare_graph(
+          map_official,
+          profile = osrm_find_profile("car.lua"),
+          verbosity = "NONE"
+        ),
+        error = identity
+      )
       options(opts)
-      
+      if (inherits(job_official, "error")) {
+        message(
+          sprintf(
+            "Skipping %s because official binaries cannot prepare the test graph: %s",
+            ver,
+            conditionMessage(job_official)
+          )
+        )
+        next
+      }
+
       opts <- options(osrm.backend.path = dir_ours)
-      server_ours <- osrm_start(job_official$osrm_job_artifact, port = 5001, verbosity = "NONE")
-      Sys.sleep(2) 
-      res_ours <- jsonlite::fromJSON("http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733")
+      server_ours <- osrm_start(
+        job_official$osrm_job_artifact,
+        port = 5001,
+        verbosity = "NONE"
+      )
+      Sys.sleep(2)
+      res_ours <- jsonlite::fromJSON(
+        "http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733"
+      )
       server_ours$kill()
       options(opts)
       Sys.sleep(1)
-      
+
       map_ours <- tempfile(fileext = ".osm.pbf")
       file.copy(test_map, map_ours)
-      
+
       opts <- options(osrm.backend.path = dir_ours)
-      job_ours <- osrm_prepare_graph(map_ours, profile = osrm_find_profile("car.lua"), verbosity = "NONE")
+      job_ours <- osrm_prepare_graph(
+        map_ours,
+        profile = osrm_find_profile("car.lua"),
+        verbosity = "NONE"
+      )
       options(opts)
-      
+
       opts <- options(osrm.backend.path = dir_official)
-      server_official <- osrm_start(job_ours$osrm_job_artifact, port = 5001, verbosity = "NONE")
+      server_official <- osrm_start(
+        job_ours$osrm_job_artifact,
+        port = 5001,
+        verbosity = "NONE"
+      )
       Sys.sleep(2)
-      res_official <- jsonlite::fromJSON("http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733")
+      res_official <- jsonlite::fromJSON(
+        "http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733"
+      )
       server_official$kill()
       options(opts)
-      
+
       expect_equal(res_ours$routes$distance, res_official$routes$distance)
       expect_equal(res_ours$routes$duration, res_official$routes$duration)
       expect_equal(res_ours$routes$geometry, res_official$routes$geometry)
+      tested_any <- TRUE
     }
   }
+
+  skip_if_not(tested_any, "No cross-provider versions could prepare graphs")
 })
 
 test_that("OSRM darwin-x64 runs under Rosetta on Apple Silicon", {
-  skip_if_not(identical(Sys.getenv("RUN_OSRM_LIVE_TESTS"), "true"), "Live OSRM tests skipped")
-  
+  skip_if_not(
+    identical(Sys.getenv("RUN_OSRM_LIVE_TESTS"), "true"),
+    "Live OSRM tests skipped"
+  )
+
   # Only run this test if we are actually on a macOS ARM64 platform
   platform <- get_platform_info()
-  skip_if_not(identical(platform$os, "darwin") && identical(platform$arch, "arm64"), "Not on macOS arm64")
-  
+  skip_if_not(
+    identical(platform$os, "darwin") && identical(platform$arch, "arm64"),
+    "Not on macOS arm64"
+  )
+
   test_map <- tempfile(fileext = ".osm.pbf")
-  download.file("https://download.geofabrik.de/europe/monaco-latest.osm.pbf", test_map, quiet = TRUE)
-  
+  download.file(
+    "https://download.geofabrik.de/europe/monaco-latest.osm.pbf",
+    test_map,
+    quiet = TRUE
+  )
+
   # Override arch to force download of x64 binary
   old_arch <- options(osrm.backend.override_arch = "x64")
   on.exit(options(old_arch), add = TRUE)
-  
+
   dir_ours_x64 <- tempfile()
   dir.create(dir_ours_x64)
-  osrm_install(version = "v26.7.2", osrm_binaries_provider = "default", dest_dir = dir_ours_x64, quiet = TRUE)
-  
+  x64_versions <- osrm_check_available_versions(prereleases = TRUE)
+  skip_if_not(length(x64_versions) > 0, "No OSRM darwin-x64 releases available")
+  osrm_install(
+    version = x64_versions[[1]],
+    osrm_binaries_provider = "default",
+    dest_dir = dir_ours_x64,
+    quiet = TRUE
+  )
+
   opts <- options(osrm.backend.path = dir_ours_x64)
   on.exit(options(opts), add = TRUE)
-  
-  job_ours <- osrm_prepare_graph(test_map, profile = osrm_find_profile("car.lua"), verbosity = "NONE")
-  server_ours <- osrm_start(job_ours$osrm_job_artifact, port = 5001, verbosity = "NONE")
+
+  job_ours <- osrm_prepare_graph(
+    test_map,
+    profile = osrm_find_profile("car.lua"),
+    verbosity = "NONE"
+  )
+  server_ours <- osrm_start(
+    job_ours$osrm_job_artifact,
+    port = 5001,
+    verbosity = "NONE"
+  )
   Sys.sleep(2)
-  res <- jsonlite::fromJSON("http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733")
+  res <- jsonlite::fromJSON(
+    "http://127.0.0.1:5001/route/v1/driving/7.419,43.731;7.418,43.733"
+  )
   server_ours$kill()
-  
+
   expect_true(!is.null(res$routes))
 })
-


### PR DESCRIPTION
Adjust live tests to only request versions that are actually available instead of hard-coding v26.7.2.\n\nChanges:\n- tests/testthat/setup-osrm.R: try installing the first available release instead of v26.7.2.\n- tests/testthat/test-compatibility.R: compute intersection of default (e-kotov/osrm-binaries) and official (Project-OSRM/osrm-backend) releases, skip when none; skip versions where official binaries fail to prepare the test graph.\n\nThis prevents CI failures when old upstream tags are not yet rebuilt. Local runs with RUN_OSRM_LIVE_TESTS=false skip the live tests as before.\n,base:main